### PR TITLE
Install APCu stable version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN buildDeps=" \
     && apt-get install -y $extraPkgs --no-install-recommends \
     && rm -rf /var/lib/apt/lists/* \
     && { yes 'no' | pecl install mongo; } \
-    && { yes '' | pecl install apcu-beta; } \
+    && { yes '' | pecl install apcu; } \
     && { yes '' | pecl install memcache-beta; } \
     && { yes '/usr' | pecl install memcached; } \
     && pecl install xdebug \


### PR DESCRIPTION
APCu is now shipped on two channels, beta and stable.

The beta version is for PHP 7, the stable version PHP 5.3+.